### PR TITLE
Improved readability and formatting

### DIFF
--- a/docs/02-Core-Concepts/06-Kube-Controller-Manager.md
+++ b/docs/02-Core-Concepts/06-Kube-Controller-Manager.md
@@ -5,7 +5,7 @@
 In this section, we will take a look at kube-controller-manager.
 
 #### Kube Controller Manager manages various controllers in kubernetes.
-- In kubernetes terms, a controller is a process that continously monitors the state of the components within the system and works towards bringing the whole system to the desired functioning state.
+- In kubernetes terms, a controller is a process that continuously monitors the state of the components within the system and works towards bringing the whole system to the desired functioning state.
 
 ## Node Controller
    - Responsible for monitoring the state of the Nodes and taking necessary actions to keep the application running. 
@@ -58,7 +58,7 @@ In this section, we will take a look at kube-controller-manager.
   
 - You can also see the running process and affective options by listing the process on master node and searching for kube-controller-manager.
   ```
-  $ ps -aux |grep kube-controller-manager
+  $ ps -aux | grep kube-controller-manager
   ```
   ![kube-controller-manager3](../../images/kube-controller-manager3.PNG)
   


### PR DESCRIPTION
Added space after pipe in command "$ ps -aux | grep kube-controller-manager " and spelling correction "continously" to "continuously"