### PR TITLE
controlplane instead of master

### DIFF
--- a/docs/03-Scheduling/17-Practice-Test-StaticPods.md
+++ b/docs/03-Scheduling/17-Practice-Test-StaticPods.md
@@ -2,7 +2,7 @@
   - Take me to [Practice Test](https://kodekloud.com/topic/practice-test-static-pods/)
   
 Solutions to the practice test - static pods
-- Run the command kubectl get pods --all-namespaces and look for those with -master appended in the name
+- Run the command kubectl get pods --all-namespaces and look for those with -controlplane appended in the name
   
   <details>
 


### PR DESCRIPTION
from the lab:
```
root@controlplane ~ ➜  kubectl get pods --all-namespaces
NAMESPACE     NAME                                   READY   STATUS    RESTARTS   AGE
kube-system   coredns-64897985d-66mrq                1/1     Running   0          5m5s
kube-system   coredns-64897985d-lzv8q                1/1     Running   0          5m5s
kube-system   etcd-controlplane                      1/1     Running   0          5m15s
kube-system   kube-apiserver-controlplane            1/1     Running   0          5m23s
kube-system   kube-controller-manager-controlplane   1/1     Running   0          5m26s
kube-system   kube-flannel-ds-bggjj                  1/1     Running   0          4m43s
kube-system   kube-flannel-ds-wj7ml                  1/1     Running   0          5m5s
kube-system   kube-proxy-fbv58                       1/1     Running   0          5m5s
kube-system   kube-proxy-mf6xv                       1/1     Running   0          4m43s
kube-system   kube-scheduler-controlplane            1/1     Running   0          5m15s
```