### PR TITLE
Removed characters not valid on UTF-8 & typos

### DIFF
--- a/docs/08-Storage/03-Storage-in-Docker.md
+++ b/docs/08-Storage/03-Storage-in-Docker.md
@@ -52,7 +52,7 @@ In this section, we will take a look at docker **Storage driver and Filesystem**
 ![class-7](../../images/class7.PNG)
 
 - Let's take an example of our application code. Since we bake our code into the image, the code is part of the image and as such, its read-only. After running a container, what if I wish to modify the source code.
-- Yes, I can still modify this file, but before I saved the modified file, Docker automatically creates a copy of the file in the read-write layer and I will then be modifying a different version of the file in the read-write layer. All future modifications will be done on this copy of the file in the read-write layer. This is called copy-on-right mechanism.
+- Yes, I can still modify this file, but before I saved the modified file, Docker automatically creates a copy of the file in the read-write layer and I will then be modifying a different version of the file in the read-write layer. All future modifications will be done on this copy of the file in the read-write layer. This is called copy-on-write mechanism.
 - The Image layer being a read-only just means that the files in these layers will not be modified in the image itself. So, the image will remain the same all the time until you rebuild the image using the Docker build command. If container destroyed then all of the data that was stored in the container layer also gets deleted.
 
 ## Volumes

--- a/docs/09-Networking/18-Practice-Test-Service-Networking.md
+++ b/docs/09-Networking/18-Practice-Test-Service-Networking.md
@@ -62,7 +62,7 @@
    From the output of the above question, you have two kube-proxy pods, e.g.
 
    ```
-   controlplane ~ ➜  kubectl get pod -n kube-system | grep kube-proxy
+   controlplane ~ kubectl get pod -n kube-system | grep kube-proxy
    kube-proxy-rtr8p                       1/1     Running   0             56m
    kube-proxy-t7w8f                       1/1     Running   0             56m
    ```

--- a/docs/12-Troubleshooting/07-Worker-Node-Failure.md
+++ b/docs/12-Troubleshooting/07-Worker-Node-Failure.md
@@ -30,7 +30,7 @@
     ```
 
     ```
-    sudo journalctl –u kubelet
+    sudo journalctl -u kubelet
     ```
     ![kublet](../../images/kublet.PNG)
   


### PR DESCRIPTION
In order to take notes on the docs I have tried to merge the docs for the sections into PDFs that I can print and write on.

The ammended files contained characters that made pandoc process fail. This PR fixes that.