### PR TITLE
use better logic to determine ipv4 address of vagrant host in bridged network, fix typos

### DIFF
--- a/kubeadm-clusters/README.md
+++ b/kubeadm-clusters/README.md
@@ -16,7 +16,7 @@ In this section we present various labs for building kubeadm clusters
 
 * Vagrant and VirtualBox
 
-    For users of Windows and Mac x86, provision a 3 node cluster on your laptop.
+    For users of Windows, Linux, and Mac x86, provision a 3 node cluster on your laptop.
 
     * [3 Node Cluster](./virtualbox/)
 

--- a/kubeadm-clusters/virtualbox/Vagrantfile
+++ b/kubeadm-clusters/virtualbox/Vagrantfile
@@ -18,7 +18,7 @@ IP_NW = "192.168.56"
 MASTER_IP_START = 11
 NODE_IP_START = 20
 
-# Host operating sysem detection
+# Host operating system detection
 module OS
   def OS.windows?
     (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
@@ -41,7 +41,7 @@ module OS
   end
 end
 
-# Determine host adpater for bridging in BRIDGE mode
+# Determine host adapter for bridging in BRIDGE mode
 def get_bridge_adapter()
   if OS.windows?
     return %x{powershell -Command "Get-NetRoute -DestinationPrefix 0.0.0.0/0 | Get-NetAdapter | Select-Object -ExpandProperty InterfaceDescription"}.chomp

--- a/kubeadm-clusters/virtualbox/ubuntu/vagrant/setup-hosts.sh
+++ b/kubeadm-clusters/virtualbox/ubuntu/vagrant/setup-hosts.sh
@@ -13,8 +13,8 @@ NODE_IP_START=$5
 if [ "$BUILD_MODE" = "BRIDGE" ]
 then
     # Determine machine IP from route table -
-    # Interface that routes to default GW that isn't on the NAT network.
-    MY_IP="$(ip route | grep default | grep -Pv '10\.\d+\.\d+\.\d+' | awk '{ print $9 }')"
+    # Interface that routes to default GW that isn't enp0s3 on the vagrant NAT network.
+    MY_IP="$(ip route | grep '^default' | awk '!/enp0s3/ { print $9 }')"
 
     # From this, determine the network (which for average broadband we assume is a /24)
     MY_NETWORK=$(echo $MY_IP | awk 'BEGIN {FS="."} ; { printf("%s.%s.%s", $1, $2, $3) }')


### PR DESCRIPTION
The current vagrant setup can't handle the situation where you have a bridged network setup with a local 10.x.x.x ip address range. This change uses better logic to choose the right interface from which we want to get the vagrant vm ip address, and fixes some typos. Fixes #169