### PR TITLE
vagrant-wait-for-ip-attribution

### DIFF
--- a/kubeadm-clusters/virtualbox/ubuntu/vagrant/setup-hosts.sh
+++ b/kubeadm-clusters/virtualbox/ubuntu/vagrant/setup-hosts.sh
@@ -14,7 +14,10 @@ if [ "$BUILD_MODE" = "BRIDGE" ]
 then
     # Determine machine IP from route table -
     # Interface that routes to default GW that isn't on the NAT network.
-    MY_IP="$(ip route | grep default | grep -Pv '10\.\d+\.\d+\.\d+' | awk '{ print $9 }')"
+    MY_IP=""
+    while [ -z "$MY_IP" ]; do
+        MY_IP="$(ip route | grep default | grep -Pv '10\.\d+\.\d+\.\d+' | awk '{ print $9 }')"
+    done
 
     # From this, determine the network (which for average broadband we assume is a /24)
     MY_NETWORK=$(echo $MY_IP | awk 'BEGIN {FS="."} ; { printf("%s.%s.%s", $1, $2, $3) }')


### PR DESCRIPTION
**Why this PR:**

When provisioning with vagrant in bridge mode, IP address assignment may be delayed. In this case, while provisioning, the host file will be incorrect because the `public-ip`command will return an empty value

**What does the PR do:**

This PR adds a loop to wait until a valid IP address is assigned before proceeding. This ensures that the public-ip command returns the correct IP and the hosts file is properly configured.




