### PR TITLE
Accessing KodeKloud Playgrounds Using Terraform from Local Machine

### DIFF
--- a/managed-clusters/aks/terraform_local/README.md
+++ b/managed-clusters/aks/terraform_local/README.md
@@ -1,0 +1,12 @@
+# AKS with Terraform from local machine
+
+Last updated: July 2025
+
+In this guide, we will deploy an AKS cluster which is compliant with the KodeKloud playground security and usage policies using terraform from local users machine. So we will be accessing KodeKloud Playgrounds Using Terraform from Local Machine and deploying an AKS .  only thing you have to take care is to refer location and resource group from locals
+
+Export below variables before executing the terraform commands
+
+export ARM_CLIENT_ID=
+export ARM_CLIENT_SECRET=
+export ARM_TENANT_ID=
+export ARM_SUBSCRIPTION_ID=

--- a/managed-clusters/aks/terraform_local/environment.sh
+++ b/managed-clusters/aks/terraform_local/environment.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Login to Azure using Service Principal
+az login --service-principal \
+  -u "$ARM_CLIENT_ID" \
+  -p "$ARM_CLIENT_SECRET" \
+  --tenant "$ARM_TENANT_ID" > /dev/null 2>&1
+
+# Get subscription ID (the one used after login)
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+
+# Get resource group starting with "kml"
+RG_NAME=$(az group list --query "[?starts_with(name, 'kml')].name | [0]" -o tsv)
+
+# Get location of that resource group
+LOCATION=$(az group show --name "$RG_NAME" --query location -o tsv)
+
+# Output in JSON format for Terraform
+echo "{
+  \"subscription_id\": \"$SUBSCRIPTION_ID\",
+  \"location\": \"$LOCATION\",
+  \"resource_group_name\": \"$RG_NAME\"
+}"

--- a/managed-clusters/aks/terraform_local/main.tf
+++ b/managed-clusters/aks/terraform_local/main.tf
@@ -1,0 +1,109 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.26.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    external = {
+      source = "hashicorp/external"
+      version = "~> 2.3"
+    }
+  }
+}
+
+variable "cluster_name" {
+    type = string
+    default = "kodekloud-demo"
+}
+
+
+# For KodeKloud Connections - Starting
+
+data "external" "environment" {
+  program = ["bash", "${path.module}/environment.sh"]
+}
+
+locals {
+  subscription_id     = data.external.environment.result["subscription_id"]  
+  location            = data.external.environment.result["location"]
+  resource_group_name = data.external.environment.result["resource_group_name"]
+}
+
+output "subscription_id" {
+  value = local.subscription_id
+}
+
+output "resource_group_name" {
+  value = local.resource_group_name
+}
+
+output "location" {
+  value = local.location
+}
+
+# For KodeKloud Connections - Ending
+
+# Configure Azure provider
+provider "azurerm" {
+  subscription_id = local.subscription_id
+  resource_provider_registrations = "none"
+  features {}
+}
+
+# Generate a random suffix for cluster's DNS prefix
+resource "random_string" "dns" {
+  length  = 6
+  upper   = false
+  lower   = false
+  numeric = true
+  special = false
+}
+
+# Deploy the cluster
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = var.cluster_name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+
+  # Preset: Dev/Test –> control‑plane tier Free
+  sku_tier = "Free"
+
+  # RBAC with local accounts (the portal default)
+  role_based_access_control_enabled = true
+  local_account_disabled            = false
+
+  # System‑assigned managed identity for the cluster
+  identity {
+    type = "SystemAssigned"
+  }
+
+  dns_prefix = "${var.cluster_name}-${random_string.dns.result}"
+
+  ############################################
+  # Default system node‑pool (manual scaling) #
+  ############################################
+  default_node_pool {
+    name               = "sysnp"          # 3–12 chars, starts with letter
+    vm_size            = "Standard_D2s_v3"
+    node_count         = 2                # manual scaling, fixed at 2
+    os_sku             = "Ubuntu"
+  }
+}
+
+# Output the AZ commands user needs to run in order to access cluster.
+output "commands" {
+    value = join("\n", [
+        "",
+        "Now run the following commands to gain kubectl access to the cluster",
+        "",
+        "az account set --subscription ${local.subscription_id}",
+        "az aks get-credentials --resource-group ${local.resource_group_name} --name ${var.cluster_name} --overwrite-existing",
+        ""
+    ])
+}


### PR DESCRIPTION
This is an extension to the Pull request (AKS Terraform #203), where it allows accessing KodeKloud Playgrounds Using Terraform from Local Machine (instead of cloud shell) and deploying resource. As an example, this terraform code will deploy an AKS in KodeKloud playground from local machine.
