### PR TITLE
Adding the upgrade settings to AKS configuration

### DIFF
--- a/managed-clusters/aks/terraform/main.tf
+++ b/managed-clusters/aks/terraform/main.tf
@@ -72,6 +72,11 @@ resource "azurerm_kubernetes_cluster" "aks" {
     vm_size            = "Standard_D2s_v3"
     node_count         = 2                # manual scaling, fixed at 2
     os_sku             = "Ubuntu"
+    upgrade_settings {
+      drain_timeout_in_minutes      = "0"
+      max_surge                     = "10%"
+      node_soak_duration_in_minutes = "0"
+    }    
   }
 }
 


### PR DESCRIPTION
Hello @fireflycons : This is an extension to the Pull request (AKS Terraform https://github.com/kodekloudhub/certified-kubernetes-administrator-course/pull/203). When the terraform apply is executed for the first time, it creates the AKS. But when the Terraform plan or apply is executed again, it will show the below changes will be made to null. And if we apply the changes the terraform will error out saying the scope is invalid for making the changes.

```
          - upgrade_settings {
              - drain_timeout_in_minutes      = 0 -> null
              - max_surge                     = "10%" -> null
              - node_soak_duration_in_minutes = 0 -> null
            }

```
So, we add the upgrade settings along with default node pool configuration. 

```
    upgrade_settings {
      drain_timeout_in_minutes      = "0"
      max_surge                     = "10%"
      node_soak_duration_in_minutes = "0"
    }    
```
By doing this, the terraform will detect as infrastructure is up-to-date with configuration.